### PR TITLE
Create contexts for API data and future dark mode feature

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3613,9 +3613,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.3.tgz",
+      "integrity": "sha512-IzwM54g4y9JA/xAeBPNaDXiBF8Jsgl3VBQ2YQ/wOY6fyW3xMdSoltIV3Bo59DErdqdE6RxUfv8W69DvUorE4Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import './App.css';
+import { DarkModeProvider } from './context/DarkModeContext'; // Shared context for dark mode
+import { BridgeProvider } from './context/BridgeContext';
 import PageLayout from "./pages/Layout";
 import HomePage from "./pages/Home";
 import About from './pages/About';
@@ -10,14 +12,19 @@ import APIPage from './pages/API';
 const App: React.FC = () => {
     return (
         <BrowserRouter>
-            <PageLayout>
-                <Routes>
-                    <Route path="/" element={<HomePage />} />
-                    <Route path="/about" element={<About />} />
-                    <Route path="/faq" element={<FAQ />} />
-                    <Route path="/api" element={<APIPage />} />
-                </Routes>
-            </PageLayout>
+            <DarkModeProvider>
+                <BridgeProvider>
+                    <PageLayout>
+                        <Routes>
+                            <Route path="/" element={<HomePage />} />
+                            <Route path="/about" element={<About />} />
+                            <Route path="/faq" element={<FAQ />} />
+                            <Route path="/api" element={<APIPage />} />
+                        </Routes>
+                    </PageLayout>
+                </BridgeProvider>
+            </DarkModeProvider>
+            
         </BrowserRouter>
     )
 }

--- a/client/src/components/BridgeMon/index.tsx
+++ b/client/src/components/BridgeMon/index.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
-import {useState, useEffect} from 'react';
-import axios from 'axios';
-import { API_BASEURL } from '../../config';
+import React, { useContext } from 'react';
+import BridgeContext from '../../context/BridgeContext';
 import Style from './index.module.css';
 import iconClosed from '../../assets/img/bridge_iconClosed.svg';
 import iconOpen from '../../assets/img/bridge_iconOpen.svg';
@@ -11,100 +9,12 @@ interface BridgeMonCard {
     isOpen: boolean;
 }
 
-type Bridge = {
-    id: string;
-    name: string;
-    region: string;
-    latitude: number;
-    longitude: number;
-    staticimg: string;
-    liveimg: string;
-    status: string;
-}
-
-const CONFIG = {
-    retryDelay: 1000
-}
-
 const BridgeMon: React.FC = () => {
     /* ***HOOKS*** */
-    const [bridgeList, setBridgeList] = useState([]); // hold response data
-    const [updateTime, setUpdateTime] = useState(0); // hold last update time
-    const [reqAttempts, setReqAttempts] = useState(0); // hold number of attempts per request
 
-    /**
-     * Get data for all bridges
-     * @returns Promise when bridge data has been fetched
-     */
-    const fetchAllBridgeData = () => {
-        const apiRoute = "get-all-bridge-data"
 
-        return new Promise(async (resolve) => {
-            try {
-                console.log("[BridgeMon]: Fetching bridge data");
-                const response = await axios.get(API_BASEURL + apiRoute);
-
-                // Check response status is 200 (OK) and data type for 'data' is 'Object'
-                if (response.status === 200 && response.data.constructor === Object) {
-                    
-                    // Sort response data by bridge ID
-                    if (response.data["bridges"].constructor === Array) { // type check
-                        response.data["bridges"].sort(dataCompare); // compare in order by bridge ID
-                    }
-
-                    setUpdateTime(response.data["LastUpdate"]);
-                    setBridgeList(response.data["bridges"]);
-                    setReqAttempts(0); // RESET request attempts counter after a successful request
-
-                } else {
-                    console.error("Response data is incorrect in type: " + response.data.constructor);
-                }
-
-                resolve(true);
-            } catch (err) {
-                if (axios.isAxiosError(err)) { // Ensure err if of Axios error type before treating it as such
-                    console.error("An error occured: " + err.message); // Log axios error
-                    //console.error(err.response?.status);
-                    if (err.response?.status === 503) { // Handle 503 (server unable to process request) - Action: Retry
-                        // Wait a few seconds and try again
-                        setTimeout(() => {
-                            console.log("Attempt after 500ms");
-                            fetchAllBridgeData();
-                        }, CONFIG.retryDelay)
-
-                        setReqAttempts(reqAttempts + 1);
-                    }
-                } else { // Log all other errors
-                    console.error(err);
-                }
-            }
-        });
-    }
-
-    /* ***FETCH bridge data on load */
-    useEffect(() => {
-        fetchAllBridgeData();
-    }, []);
-
-    /* ***FETCH bridge data on 60 second intervals*** */
-    useEffect(() => {
-        setTimeout(() => {
-            fetchAllBridgeData();
-        }, 60000); // Refresh every 1 minute
-    });
-
-    /* Helper Function - Compare function (think Java Comparable) for bridge API data */
-    function dataCompare(a: Bridge, b: Bridge) {
-        if (a.id < b.id) {
-            return -1; // a < b
-        } else if (a.id > b.id) {
-            return 1; // a > b
-        } else {
-            return 0; // must be equal
-        }
-    }
-
-    
+    // React Context Hooks
+    const {bridgeList, updateTime} = useContext(BridgeContext);
 
     /* Generate page data */
     return (

--- a/client/src/context/BridgeContext.tsx
+++ b/client/src/context/BridgeContext.tsx
@@ -1,0 +1,125 @@
+import { createContext, useState, useEffect } from "react";
+import axios from 'axios';
+import { API_BASEURL } from '../config';
+
+/**
+ * Bridge type declaration
+ */
+type Bridge = {
+    id: string;
+    name: string;
+    region: string;
+    latitude: number;
+    longitude: number;
+    staticimg: string;
+    liveimg: string;
+    bridge_type: string;
+    short_name: string;
+    status: string;
+}
+
+/**
+ * BridgeDataContext type - to define context values
+ */
+type BridgeDataContext = {
+    bridgeList: Bridge[];
+    updateTime: number;
+}
+
+/**
+ * Configuration settings
+ */
+const CONFIG = {
+    retryDelay: 1000
+}
+
+// Create Context
+const BridgeContext = createContext<BridgeDataContext>({} as BridgeDataContext);
+
+export const BridgeProvider = ({ children }: React.PropsWithChildren) => {
+    /* ***HOOKS*** */
+    const [bridgeList, setBridgeList] = useState([]); // hold response data
+    const [updateTime, setUpdateTime] = useState(0); // hold last update time
+    const [reqAttempts, setReqAttempts] = useState(0); // hold number of attempts per request
+
+    /**
+     * Get data for all bridges
+     * @returns Promise when bridge data has been fetched
+     */
+    const fetchAllBridgeData = () => {
+        const apiRoute = "get-all-bridge-data"
+
+        return new Promise(async (resolve) => {
+            try {
+                console.log("[BridgeMon]: Fetching bridge data");
+                const response = await axios.get(API_BASEURL + apiRoute);
+
+                // Check response status is 200 (OK) and data type for 'data' is 'Object'
+                if (response.status === 200 && response.data.constructor === Object) {
+                    
+                    // Sort response data by bridge ID
+                    if (response.data["bridges"].constructor === Array) { // type check
+                        response.data["bridges"].sort(dataCompare); // compare in order by bridge ID
+                    }
+
+                    setUpdateTime(response.data["LastUpdate"]);
+                    setBridgeList(response.data["bridges"]);
+                    setReqAttempts(0); // RESET request attempts counter after a successful request
+
+                } else {
+                    console.error("Response data is incorrect in type: " + response.data.constructor);
+                }
+
+                resolve(true);
+            } catch (err) {
+                if (axios.isAxiosError(err)) { // Ensure err if of Axios error type before treating it as such
+                    console.error("An error occured: " + err.message); // Log axios error
+                    //console.error(err.response?.status);
+                    if (err.response?.status === 503) { // Handle 503 (server unable to process request) - Action: Retry
+                        // Wait a few seconds and try again
+                        setTimeout(() => {
+                            console.log("Attempt after 500ms");
+                            fetchAllBridgeData();
+                        }, CONFIG.retryDelay)
+
+                        setReqAttempts(reqAttempts + 1);
+                    }
+                } else { // Log all other errors
+                    console.error(err);
+                }
+            }
+        });
+    }
+
+    /* ***FETCH bridge data on load */
+    useEffect(() => {
+        fetchAllBridgeData();
+    }, []);
+
+    /* ***FETCH bridge data on 60 second intervals*** */
+    useEffect(() => {
+        setTimeout(() => {
+            fetchAllBridgeData();
+        }, 60000); // Refresh every 1 minute
+    });
+
+    /* Helper Function - Compare function (think Java Comparable) for bridge API data */
+    function dataCompare(a: Bridge, b: Bridge) {
+        if (a.id < b.id) {
+            return -1; // a < b
+        } else if (a.id > b.id) {
+            return 1; // a > b
+        } else {
+            return 0; // must be equal
+        }
+    }
+
+
+    return (
+        <BridgeContext.Provider value={{bridgeList, updateTime}}>
+            { children }
+        </BridgeContext.Provider>
+    );
+}
+
+export default BridgeContext;

--- a/client/src/context/BridgeContext.tsx
+++ b/client/src/context/BridgeContext.tsx
@@ -52,7 +52,7 @@ export const BridgeProvider = ({ children }: React.PropsWithChildren) => {
         return new Promise(async (resolve) => {
             try {
                 console.log("[BridgeMon]: Fetching bridge data");
-                const response = await axios.get(API_BASEURL + apiRoute);
+                const response = await axios.get(API_BASEURL + apiRoute, {params: {timetags: true}});
 
                 // Check response status is 200 (OK) and data type for 'data' is 'Object'
                 if (response.status === 200 && response.data.constructor === Object) {

--- a/client/src/context/BridgeContext.tsx
+++ b/client/src/context/BridgeContext.tsx
@@ -30,6 +30,7 @@ type BridgeDataContext = {
  * Configuration settings
  */
 const CONFIG = {
+    updateInterval: 60000,
     retryDelay: 1000
 }
 
@@ -93,15 +94,14 @@ export const BridgeProvider = ({ children }: React.PropsWithChildren) => {
 
     /* ***FETCH bridge data on load */
     useEffect(() => {
+        /* ***Perform initial data fetch ON LOAD */
         fetchAllBridgeData();
-    }, []);
 
-    /* ***FETCH bridge data on 60 second intervals*** */
-    useEffect(() => {
-        setTimeout(() => {
+        /* ***FETCH bridge data on a certain intervals*** */
+        setInterval(() => {
             fetchAllBridgeData();
-        }, 60000); // Refresh every 1 minute
-    });
+        }, CONFIG.updateInterval)
+    }, []);
 
     /* Helper Function - Compare function (think Java Comparable) for bridge API data */
     function dataCompare(a: Bridge, b: Bridge) {

--- a/client/src/context/DarkModeContext.tsx
+++ b/client/src/context/DarkModeContext.tsx
@@ -1,0 +1,24 @@
+import {createContext, useState} from 'react';
+
+type DarkModeType = {
+    darkMode: boolean,
+    toggleDarkMode: () => void
+}
+
+const DarkModeContext = createContext<DarkModeType>({} as DarkModeType);
+
+export const DarkModeProvider = ({ children }: React.PropsWithChildren) => {
+    const [darkMode, setDarkMode] = useState(false);
+
+    const toggleDarkMode = () => {
+        setDarkMode(!darkMode);
+    }
+
+    return (
+        <DarkModeContext.Provider value={{darkMode, toggleDarkMode}}>
+            {children}
+        </DarkModeContext.Provider>
+    );
+}
+
+export default DarkModeContext;

--- a/client/src/pages/Home/index.tsx
+++ b/client/src/pages/Home/index.tsx
@@ -1,20 +1,7 @@
-import React from 'react';
-import {useState, useEffect} from 'react';
-import axios from 'axios';
-import { API_BASEURL } from '../../config';
+import React, { useContext } from 'react';
+import BridgeContext from '../../context/BridgeContext';
 import Style from './index.module.css';
 import BridgeMon from '../../components/BridgeMon';
-
-type Bridge = {
-    id: string;
-    name: string;
-    region: string;
-    latitude: number;
-    longitude: number;
-    staticimg: string;
-    liveimg: string;
-    status: string;
-}
 
 interface BridgeCard {
     bridgeName: string;
@@ -24,87 +11,12 @@ interface BridgeCard {
     liveImg: string;
 }
 
-const CONFIG = {
-    retryDelay: 1000
-}
-
 const Home: React.FC = () => {
     /* ***HOOKS*** */
-    const [bridgeList, setBridgeList] = useState([]); // hold response data
-    const [updateTime, setUpdateTime] = useState(0); // hold last update time
-    const [reqAttempts, setReqAttempts] = useState(0); // hold number of attempts per request
 
-    /**
-     * Get data for all bridges
-     * @returns Promise when bridge data has been fetched
-     */
-    const fetchAllBridgeData = () => {
-        const apiRoute = "get-all-bridge-data"
 
-        return new Promise(async (resolve) => {
-            try {
-                console.log("[BridgeMon]: Fetching bridge data");
-                const response = await axios.get(API_BASEURL + apiRoute, {params: {timetags: true}});
-
-                // Check response status is 200 (OK) and data type for 'data' is 'Object'
-                if (response.status === 200 && response.data.constructor === Object) {
-                    
-                    // Sort response data by bridge ID
-                    if (response.data["bridges"].constructor === Array) { // type check
-                        response.data["bridges"].sort(dataCompare); // compare in order by bridge ID
-                    }
-
-                    setUpdateTime(response.data["LastUpdate"]);
-                    setBridgeList(response.data["bridges"]);
-                    setReqAttempts(0); // RESET request attempts counter after a successful request
-
-                } else {
-                    console.error("Response data is incorrect in type: " + response.data.constructor);
-                }
-
-                resolve(true);
-            } catch (err) {
-                if (axios.isAxiosError(err)) { // Ensure err if of Axios error type before treating it as such
-                    console.error("An error occured: " + err.message); // Log axios error
-                    //console.error(err.response?.status);
-                    if (err.response?.status === 503) { // Handle 503 (server unable to process request) - Action: Retry
-                        // Wait a few seconds and try again
-                        setTimeout(() => {
-                            console.log("Attempt after 500ms");
-                            fetchAllBridgeData();
-                        }, CONFIG.retryDelay)
-
-                        setReqAttempts(reqAttempts + 1);
-                    }
-                } else { // Log all other errors
-                    console.error(err);
-                }
-            }
-        });
-    }
-
-    /* ***FETCH bridge data on load */
-    useEffect(() => {
-        fetchAllBridgeData();
-    }, []);
-
-    /* ***FETCH bridge data on 60 second intervals*** */
-    useEffect(() => {
-        setTimeout(() => {
-            fetchAllBridgeData();
-        }, 60000); // Refresh every 1 minute
-    });
-
-    /* Helper Function - Compare function (think Java Comparable) for bridge API data */
-    function dataCompare(a: Bridge, b: Bridge) {
-        if (a.id < b.id) {
-            return -1; // a < b
-        } else if (a.id > b.id) {
-            return 1; // a > b
-        } else {
-            return 0; // must be equal
-        }
-    }
+    // React Context Hooks
+    const {bridgeList, updateTime} = useContext(BridgeContext);
     
     /* ***Main page Content*** */
     return (


### PR DESCRIPTION
Move API requests to its own React context to reduce code redundancy and improve reliability. Additional fixes make it so that the frontend only sends out a single request per 60 seconds, mitigating a long-standing bug.